### PR TITLE
fixes orbitdb link

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
     <script src="vendor/mirador/mirador.js"></script>
     <script src="node_modules/ipfs-api/dist/index.js"></script>
-    <script src="node_modules/orbit-db/dist/orbitdb.js"></script>
+    <script src="node_modules/orbit-db/dist/orbitdb.min.js"></script>
     <script src="index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I'm not sure if you want to merge this.  On my machine, npm installed orbitdb.min.js instead of orbitdb.js, so I had to update the link in index.html in order for anno to work.